### PR TITLE
Update template JSON to be compatible with Eureka 1.3.1 changes

### DIFF
--- a/eurekaclient.go
+++ b/eurekaclient.go
@@ -46,12 +46,19 @@ var regTpl = `{
     "ipAddr":"${ipAddress}",
     "vipAddress":"${appName}",
     "status":"UP",
-    "port":"${port}",
-    "securePort" : "${securePort}",
+    "port": {
+      "$":${port},
+      "@enabled": true
+    },
+    "securePort": {
+      "$":${securePort},
+      "@enabled": true
+    },
     "homePageUrl" : "http://${ipAddress}:${port}/",
     "statusPageUrl": "http://${ipAddress}:${port}/info",
     "healthCheckUrl": "http://${ipAddress}:${port}/health",
     "dataCenterInfo" : {
+      "@class":"com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo",
       "name": "MyOwn"
     },
     "metadata": {


### PR DESCRIPTION
The "@ class": "com.netflix.appinfo.MyDataCenterInfo"
is mandatory with Eureka 1.3.1.

Additionally, this fix addresses an issue introduced with Eureka release 1.2.2.
It introduced the Jackson codec, which brings along
encoding the ports"as integers ("port" and "securePort") .